### PR TITLE
Spell fix from "tolerence" to "tolerance"

### DIFF
--- a/doc/examples/ubond.conf.in
+++ b/doc/examples/ubond.conf.in
@@ -65,11 +65,11 @@ cleartext_data = 0
 # reorder_buffer_size is 0 (disabled) by default.
 #reorder_buffer_size = 64
 
-# Loss tolerence
+# Loss tolerance
 # Defines the maximum loss ratio accepted before the link affected is being
 # considered too lossy and removed from agregation.
 # This value is expressed in percent.
-#loss_tolerence = 10
+#loss_tolerance = 10
 
 # Filtering system
 # when UBOND is configured to balance traffic across multiple links
@@ -106,7 +106,7 @@ bindport = 5080
 #remoteport = 5081
 # If it is a lossy link and we want to keep using it,
 # even if 30% of packets are lost
-#loss_tolerence = 30
+#loss_tolerance = 30
 #bandwidth_upload = 512000
 
 #[dsl2]

--- a/doc/source/filters_guide.rst
+++ b/doc/source/filters_guide.rst
@@ -34,7 +34,7 @@ ubond.conf
     # configuration file provided with your distribution package.
     #
     reorder_buffer_size 64
-    loss_tolerence = 50
+    loss_tolerance = 50
 
     [filters]
     sdsl = udp port 5060

--- a/doc/source/linux_example.rst
+++ b/doc/source/linux_example.rst
@@ -326,7 +326,7 @@ Take a look at example config files for more details. (**man ubond.conf** can be
     timeout = 30
     password = "you have not changed me yet?"
     reorder_buffer_size = 64
-    loss_tolerence = 50
+    loss_tolerance= 50
 
     [filters]
 
@@ -401,7 +401,7 @@ ubond0.conf
     timeout = 30
     password = "pleasechangeme!"
     reorder_buffer_size = 64
-    loss_tolerence = 50
+    loss_tolerance = 50
 
     [filters]
 

--- a/man/ubond.conf.5
+++ b/man/ubond.conf.5
@@ -102,13 +102,13 @@ Experiment to know what value is best for you\. Good starting point can be as sm
 \fB0\fR disables the reordering\.
 .
 .IP "\(bu" 4
-\fIloss_tolerence\fR = 0 ubond monitors packet loss on every link\. If the packet loss ratio on a link exceed the specified value in percent, the link changes state to UBOND_LOSSY and is removed from aggregation\.
+\fIloss_tolerance\fR = 0 ubond monitors packet loss on every link\. If the packet loss ratio on a link exceed the specified value in percent, the link changes state to UBOND_LOSSY and is removed from aggregation\.
 .
 .IP
 Lossy links ARE used anyway if no other choices are available (if all links are lossy)
 .
 .IP
-\fB100 or more\fR disables the loss tolerence system\.
+\fB100 or more\fR disables the loss tolerance system\.
 .
 .IP "" 0
 .
@@ -178,7 +178,7 @@ Status availables: \fB!\fR: down, \fB@\fR: up, \fB~\fR: lossy
 Example: \fBubond: adsl3g !3g @adsl ~wifi\fR
 .
 .P
-3g is \fBdown\fR, adsl is \fBup\fR and wifi is \fBlossy\fR (up, but above loss_tolerence threshold)\.
+3g is \fBdown\fR, adsl is \fBup\fR and wifi is \fBlossy\fR (up, but above loss_tolerance threshold)\.
 .
 .SH "EXAMPLE"
 See examples/ubond\.conf

--- a/man/ubond.conf.5.ronn
+++ b/man/ubond.conf.5.ronn
@@ -84,7 +84,7 @@ The **[general]** section is reserved for global configuration.
 
     **0** disables the reordering.
 
-  - _loss_tolerence_ = 0
+  - _loss_tolerance = 0
     ubond monitors packet loss on every link. If the packet loss
     ratio on a link exceeds the specified value in percent,
     the link changes state to UBOND_LOSSY and is removed from aggregation.
@@ -92,7 +92,7 @@ The **[general]** section is reserved for global configuration.
     Lossy links ARE used anyway if no other choices are available (if all links
     are lossy)
 
-    **100 or more** disables the loss tolerence system.
+    **100 or more** disables the loss tolerance system.
 
 
 ### TUNNELS
@@ -163,7 +163,7 @@ Status availables: **!**: down, **@**: up, **~**: lossy
 
 Example: `ubond: adsl3g !3g @adsl ~wifi`
 
-3g is **down**, adsl is **up** and wifi is **lossy** (up, but above loss_tolerence threshold).
+3g is **down**, adsl is **up** and wifi is **lossy** (up, but above loss_tolerance threshold).
 
 ## EXAMPLE
 

--- a/src/ubond.c
+++ b/src/ubond.c
@@ -541,7 +541,7 @@ int ubond_loss_pack(ubond_tunnel_t *t)
   // 50:50 current loss, and average loss as a %
   // or should we say current loss from 0-lt + average loss...?
 
-  // cut off at the loss tolerence
+  // cut off at the loss tolerance 
   if (ploss >= lt) return lt;
   int v=(int)(((ploss * lt)+(lt/2.0)-0.5) / lt);
   return v;


### PR DESCRIPTION
Hope this doesn't sound pedantic! I spent a whole day figuring out why loss_tolerance wasn't working ;) 
It's very easy to overlook the letter.
I'm guessing the reason for the misspell is that it may conflict when testing other branches/MLVPN with the same configuration files? MLVPN needs to fix that too.
Thanks.